### PR TITLE
fix: Handle API errors better

### DIFF
--- a/zeno_client/__init__.py
+++ b/zeno_client/__init__.py
@@ -1,4 +1,5 @@
 """Python client for creating and managing Zeno projects."""
 from .client import ZenoClient, ZenoMetric, ZenoProject
+from .exceptions import APIError
 
-__all__ = ["ZenoClient", "ZenoMetric", "ZenoProject"]
+__all__ = ["ZenoClient", "ZenoMetric", "ZenoProject", "APIError"]

--- a/zeno_client/client.py
+++ b/zeno_client/client.py
@@ -58,7 +58,7 @@ class ZenoProject:
         """
         self.api_key = api_key
         self.project_uuid = project_uuid
-        self.endpoint = endpoint 
+        self.endpoint = endpoint
 
     def upload_dataset(
         self,

--- a/zeno_client/exceptions.py
+++ b/zeno_client/exceptions.py
@@ -1,4 +1,10 @@
+"""Exceptions for the Zeno Client."""
+
+
 class APIError(Exception):
+    """Exception raised when an API call fails."""
+
     def __init__(self, message, status_code):
+        """Initialize exception."""
         super().__init__(message)
         self.status_code = status_code

--- a/zeno_client/exceptions.py
+++ b/zeno_client/exceptions.py
@@ -1,0 +1,5 @@
+
+class APIError(Exception):
+    def __init__(self, message, status_code):
+        super().__init__(message)
+        self.status_code = status_code

--- a/zeno_client/exceptions.py
+++ b/zeno_client/exceptions.py
@@ -1,4 +1,3 @@
-
 class APIError(Exception):
     def __init__(self, message, status_code):
         super().__init__(message)


### PR DESCRIPTION
# Description

This PR makes two changes:

1. It makes handling of API errors more robust by catching cases where the response is not JSON
2. It stops using the general `Exception` class (which doesn't provide information about what type of error it is), and separates into Python `ValueError` and a new `zeno-client` `APIError` class.

# References

- In service of fixing https://linear.app/zenoml/issue/ZEN-148/bug-502-error-and-ensuing-json-decoding-error-when-uploading-large

# Blocked by

- NA
