### PR TITLE
fix: prevent auto-overwrite of project values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zeno-client"
-version = "0.1.13"
+version = "0.1.15"
 description = "Python client for creating new Zeno projects and uploading data."
 authors = ["Zeno Team <hello@zenoml.com>"]
 license = "MIT"

--- a/zeno_client/client.py
+++ b/zeno_client/client.py
@@ -305,10 +305,10 @@ class ZenoClient:
         *,
         name: str,
         view: Union[str, Dict] = "",
-        description: str = "",
+        description: str | None = None,
         metrics: List[ZenoMetric] = [],
-        samples_per_page: int = 10,
-        public: bool = False,
+        samples_per_page: int | None = None,
+        public: bool | None = None,
     ) -> ZenoProject:
         """Creates an empty project in Zeno's backend.
 
@@ -321,8 +321,9 @@ class ZenoClient:
             metrics (list[ZenoMetric], optional): The metrics to calculate for the
                 project. Defaults to [].
             samples_per_page (int, optional): The number of samples to show per page.
-                Defaults to 10.
-            public (bool, optional): Whether the project is public. Defaults to False.
+                Defaults to None.
+            public (bool | None, optional): Whether the project is public.
+                Defaults to None.
 
         Returns:
             ZenoProject | None: The created project object or None if the project could


### PR DESCRIPTION
# Description

Prevents auto-overwrite of project fields:
`public`, `description`, and `samples_per_page`.

They are now `None` by default.

Needs to be merged with https://github.com/zeno-ml/zeno-hub/pull/610
